### PR TITLE
Additional k9s helpers

### DIFF
--- a/configs/k9s/aliases.yaml
+++ b/configs/k9s/aliases.yaml
@@ -1,5 +1,5 @@
 # vim:ft=yaml
-
+# $XDG_CONFIG_HOME/k9s/aliases.yaml
 aliases:
   cr: rbac.authorization.k8s.io/v1/clusterroles
   crb: rbac.authorization.k8s.io/v1/clusterrolebindings

--- a/configs/k9s/config.yaml
+++ b/configs/k9s/config.yaml
@@ -1,16 +1,25 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/config.yaml
 k9s:
   liveViewAutoRefresh: false
+  gpuVendors: {}
   refreshRate: 2
+  apiServerTimeout: 15s
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false
+  portForwardAddress: localhost
   ui:
     enableMouse: false
     headless: false
     logoless: true
     crumbsless: false
+    splashless: true
+    reactive: false
     noIcons: false
     skin: default
+    defaultsToFullScreen: false
+    useFullGVRTitle: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
@@ -29,6 +38,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:
@@ -37,3 +47,4 @@ k9s:
     memory:
       critical: 90
       warn: 70
+  defaultView: ""

--- a/configs/k9s/hotkeys.yaml
+++ b/configs/k9s/hotkeys.yaml
@@ -1,3 +1,5 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/hotkeys.yaml
 hotKeys:
   shift-0:
     shortCut:    Shift-0

--- a/configs/k9s/plugins/search-journal.yaml
+++ b/configs/k9s/plugins/search-journal.yaml
@@ -1,5 +1,7 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/plugins/search-journal.yaml
 # show warnings for your current cluster and copy the log line on pressing enter
-# requires fzf, jq
+# requires fzf, gum
 plugins:
   search-journal:
     shortCut: Shift-J
@@ -31,13 +33,25 @@ plugins:
         else
           echo "Connecting to node:      ${GREEN}${CHOSEN_INSTANCE}${RESET}"
           echo "Hostname:                ${GREEN}${NODE}${RESET}"
-          echo "Connection started from: ${GREEN}${NAME}${RESET}"
-          echo "Resource type:           ${GREEN}${TYPE}${RESET}"
-          aws ssm send-command \
-            --instance-ids "${CHOSEN_INSTANCE}" \
-            --document-name "AWS-RunShellScript" \
-            --comment "IP config" \
-            --parameters "commands=ifconfig"
+          JOURNAL=$(gum spin --spinner points --title "Running journalctl" -- \
+            aws ssm start-session \
+              --document-name 'AWS-StartNonInteractiveCommand' \
+              --parameters '{"command": ["sudo journalctl --utc --no-pager --no-hostname -q -r  -o short-full"]}' \
+              --target "${CHOSEN_INSTANCE}")
+          clear
+
+          echo "${JOURNAL}" | \
+          fzf \
+            --bind 'ctrl-c:accept' \
+            --bind 'enter:execute-silent(echo {+} | pbcopy)+accept' \
+            --bind 'esc:accept' \
+            --bind pg'dn:page-down' \
+            --bind pgu'p:page-up' \
+            --border \
+            --height=75% \
+            --prompt="Query journal for node ${CHOSEN_INSTANCE}: " \
+            --preview "echo {}" \
+            --preview-window=bottom,wrap
           exit
         fi
         exit

--- a/configs/k9s/plugins/shell-node.yaml
+++ b/configs/k9s/plugins/shell-node.yaml
@@ -1,3 +1,5 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/plugins/shell-node.yaml
 # pick a node and connect to it via ssm
 # requires aws cli, fzf, jq
 plugins:

--- a/configs/k9s/plugins/show-warnings.yaml
+++ b/configs/k9s/plugins/show-warnings.yaml
@@ -1,3 +1,5 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/plugins/show-warnings.yaml
 # show warnings for your current cluster and copy the log line on pressing enter
 # requires fzf, jq
 plugins:

--- a/configs/k9s/plugins/trace-dns.yaml
+++ b/configs/k9s/plugins/trace-dns.yaml
@@ -1,3 +1,5 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/plugins/trace-dns.yaml
 # Author: Qasim Sarfraz
 # Trace DNS requests for containers, pods, and nodes
 # Requires kubectl version 1.30 or later
@@ -40,7 +42,7 @@ plugins:
         if [[ -n "$POD" ]]; then
           echo -e "${GREEN}Tracing DNS requests for container ${BLUE}${NAME}${GREEN} in pod ${BLUE}${POD}${GREEN} in namespace ${BLUE}${NAMESPACE}${NC}"
           IG_NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
-          kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+          kubectl debug --kubeconfig=$KUBECONFIG --context=$CONTEXT -q \
             --profile=sysadmin -it --image="$IG_IMAGE" "node/$IG_NODE" -- \
             ig run trace_dns:$IG_VERSION -F "k8s.podName==$POD" -F "k8s.containerName=$NAME" \
             --fields "$IG_FIELD"
@@ -51,7 +53,7 @@ plugins:
         if [[ -n "$NAMESPACE" ]]; then
           echo -e "${GREEN}Tracing DNS requests for pod ${BLUE}${NAME}${GREEN} in namespace ${BLUE}${NAMESPACE}${NC}"
           IG_NODE=$(kubectl get pod "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
-          kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+          kubectl debug --kubeconfig=$KUBECONFIG --context=$CONTEXT -q \
             --profile=sysadmin -it --image="$IG_IMAGE" "node/$IG_NODE" -- \
             ig run trace_dns:$IG_VERSION -F "k8s.podName==$NAME" \
             --fields "$IG_FIELD"
@@ -60,6 +62,6 @@ plugins:
         
         # Handle nodes
         echo -e "${GREEN}Tracing DNS requests for node ${BLUE}${NAME}${NC}"
-        kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+        kubectl debug --kubeconfig=$KUBECONFIG --context=$CONTEXT -q \
           --profile=sysadmin -it --image="$IG_IMAGE" "node/$NAME" -- \
           ig run trace_dns:$IG_VERSION --fields "$IG_FIELD"

--- a/configs/k9s/plugins/watch-events.yaml
+++ b/configs/k9s/plugins/watch-events.yaml
@@ -1,3 +1,5 @@
+# vim:ft=yaml
+# $XDG_CONFIG_HOME/k9s/plugins/watch-events.yaml
 # watch events on selected resources
 # requires linux "watch" command
 # change '-n' to adjust refresh time in seconds

--- a/configs/k9s/views.yaml
+++ b/configs/k9s/views.yaml
@@ -1,3 +1,4 @@
+# vim:ft=yaml
 # $XDG_CONFIG_HOME/k9s/views.yaml
 views:
   v1/nodes:

--- a/customisations/env
+++ b/customisations/env
@@ -19,4 +19,7 @@ export FZF_DEFAULT_OPTS="\
 "
 
 # Add fettle-it/bin to the PATH
-export PATH=~/.fettle-it/bin:$PATH
+export PATH=~/.fettle-it/bin:${PATH}
+
+# Set XDG paths
+export XDG_CONFIG_HOME="${HOME}/.config"

--- a/install
+++ b/install
@@ -8,14 +8,6 @@ set -o errexit
 application_configs() {
   step "Application configurations"
   if [ "${TYPE}" = "work" ]; then
-    substep "k9s"
-    k9s_config="# vim: ft=bash
-# Source k9s configs rather than symlinking them
-export K9S_CONFIG_DIR=~/.fettle-it/configs/k9s
-export K9S_LOGS_DIR=~/.fettle-it/configs/k9s/logs"
-    append_to_file "${k9s_config}" "${HOME}/.fettle-it/customisations/work.env"
-    substep_done "k9s ➡ complete"
-
     substep "MeetingBar"
     open -g -a MeetingBar
 
@@ -214,6 +206,17 @@ source_customisations() {
 
 symlink_configs() {
   step "Symlinking configurations"
+  if [ "${TYPE}" = "work" ]; then
+    substep "k9s"
+    ln -sf ~/.fettle-it/configs/k9s ~/.config &>/dev/null
+    k9s_config="# vim: ft=bash
+# Source k9s config
+export K9S_CONFIG_DIR=~/.config/k9s
+export K9S_LOGS_DIR=~/.config/k9s/logs"
+    append_to_file "${k9s_config}" "${HOME}/.fettle-it/customisations/work.env"
+    substep_done "k9s ➡ complete"
+  fi
+
   substep "AltTab"
   ln -sf  ~/.fettle-it/configs/alttab/com.lwouis.alt-tab-macos.plist ~/Library/Preferences/com.lwouis.alt-tab-macos.plist &>/dev/null
   defaults import lcom.lwouis.alt-tab-macos.plist ~/.fettle-it/configs/alttab/com.lwouis.alt-tab-macos.plist


### PR DESCRIPTION
Add the ability to
- shell onto the node behind the highlighted resource for
  - pods
  - containers
  - nodes
- show warnings for the environment and search them
- watch events as they're coming in
- trace dns calls for specific resources
- search the journal - WIP