### PR TITLE
Add a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+.PHONY: install
+install:
+	@./install
+
+.PHONY: deps
+deps:
+	@./install --dependencies
+
+.PHONY: personal
+personal:
+	@./install --personal
+
+.PHONY: personal-deps
+personal-deps:
+	@./install --personal --dependencies
+
+.PHONY: personal-no-deps
+personal-no-deps:
+	@./install --personal --no-dependencies
+
+.PHONY: pn
+pn:
+	make personal-no-deps
+
+.PHONY: update
+update:
+	@gum spin --spinner points --title "Updating homebrew" -- brew update
+	@make deps
+
+.PHONY: wn
+wn:
+	make work-no-deps
+
+.PHONY: work
+work:
+	@./install --work
+
+.PHONY: work-deps
+work-deps:
+	@./install --work --dependencies
+
+.PHONY: work-no-deps
+work-no-deps:
+	@./install --work --no-dependencies

--- a/install
+++ b/install
@@ -175,10 +175,11 @@ print_help() {
   echo "Fettle your machine by installing some standard stuff"
   echo ""
   echo "options:"
-  echo "  -h | --help      Displays this message"
-  echo "  -n | --no-deps   Don't install dependencies"
-  echo "  -p | --personal  Fettle your machine for personal use"
-  echo "  -w | --work      Fettle your machine for work use"
+  echo "  -h  | --help             Displays this message"
+  echo "  -d  | --dependencies     Only install dependencies. Can be used with -p or -w"
+  echo "  -n  | --no-dependencies  Don't install dependencies Can be used with -p or -w"
+  echo "  -p  | --personal         Fettle your machine for personal use"
+  echo "  -w  | --work             Fettle your machine for work use"
   echo ""
   exit 1
 }
@@ -250,11 +251,15 @@ do
     -h|--help)
     print_help
     ;;
+    -d|--dependencies)
+    install_dependencies
+    exit
+    ;;
+    -n|--no-dependencies)
+    DEPS=false
+    ;;
     -p|--personal)
     TYPE="personal"
-    ;;
-    -n|--no-deps)
-    DEPS=false
     ;;
     -w|--work)
     TYPE="work"


### PR DESCRIPTION
Arguably excessive but who doesn't like a shorcut for everything?

Added updated help messages. Can now optionally
- install deps
- not install deps
- specify work or personal
- do combinations e.g. `./install -w -n` with configure things for work but skip the dependencies
- add targets for same e.g. `make wn` will do the same thing as `./install -w -n` but without all the typing

Pointless really.